### PR TITLE
fix: control order of values in flattened list of config dict values

### DIFF
--- a/lib/conftest.py
+++ b/lib/conftest.py
@@ -20,7 +20,7 @@ def config():
                     "all-stratifications": "vWhatever.all-stratifications.tsv",
                     "region-definitions": [
                         {"name": "*", "label": "everybody", "inclusion": ".*"},
-                        {"name": "name1", "label": "some1", "inclusion": ".*"},
+                        {"name": "name1", "inclusion": ".*", "label": "some1"},
                         {"name": "name2", "label": "some2", "inclusion": ".*"},
                     ],
                 },

--- a/lib/target_construction.py
+++ b/lib/target_construction.py
@@ -234,3 +234,27 @@ def get_happy_stratification_set_indices(wildcards, config, checkpoints):
     ).set_index("key", drop=False)
     regions = regions.loc[stratification_sets]
     return [x for x in range(ceil(len(regions) / beds_per_set))]
+
+
+def flatten_region_definitions(config: dict, reference_build: str) -> list:
+    """
+    Snakemake flattens certain types of configuration dict structures into
+    simple string lists when passing the structures into scripts. This flattening
+    is awkward but functional. However, in order to use the flattened list,
+    which evidently strips the keys from the dict, one must assume the fixed
+    order of the values in the config. The yaml package seems to preserve
+    the order of the keys as observed in the config file, which creates the
+    possibility that a user might provide a shuffled but valid specification
+    of a region and then break the logic that assumes the key order incorrectly.
+
+    As such, we need to flatten it manually, enforcing order.
+    """
+    region_definitions = config["genomes"][reference_build]["stratification-regions"][
+        "region-definitions"
+    ]
+    res = []
+    for region_definition in region_definitions:
+        res.extend(
+            [region_definition["name"], region_definition["label"], region_definition["inclusion"]]
+        )
+    return res

--- a/lib/test_target_construction.py
+++ b/lib/test_target_construction.py
@@ -103,3 +103,13 @@ def test_map_experimental_file(wildcards_comparison, manifest_experiment):
     expected = "path/to/exp_filename.vcf.gz"
     observed = tc.map_experimental_file(wildcards_comparison, manifest_experiment)
     assert observed == expected
+
+
+def test_flatten_region_definitions(config):
+    """
+    Test that flatten_region_definitions can convert a list of dicts
+    to a flattened string list with preserved value ordering.
+    """
+    expected = ["*", "everybody", ".*", "name1", "some1", ".*", "name2", "some2", ".*"]
+    observed = tc.flatten_region_definitions(config, "grch100")
+    assert observed == expected

--- a/workflow/rules/reports.smk
+++ b/workflow/rules/reports.smk
@@ -13,9 +13,9 @@ rule control_validation_report:
     params:
         manifest_experiment=manifest_experiment,
         manifest_reference=manifest_reference,
-        selected_stratifications=config["genomes"][reference_build]["stratification-regions"][
-            "region-definitions"
-        ],
+        selected_stratifications=lambda wildcards: tc.flatten_region_definitions(
+            config, reference_build
+        ),
         comparison_subjects=lambda wildcards: tc.get_happy_comparison_subjects(
             wildcards, manifest_experiment, manifest_comparisons
         ),


### PR DESCRIPTION
see comment in lib/target_construction.py for the description of the issue. in short, order in the config is flexible but needs to be enforced when passing the dict into a python script via snakemake params