### PR TITLE
feat: track individual files within stratification regions with http remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ under each block:
 |`confident-regions`|arbitrarily many bedfiles describing a confident background on which comparison should be evaluated. the names under `confident-regions` are unique identifiers labeling the region type, and contain the following key/value pairs|
 ||`bed`: bed regions in which to compute calculations. high-confidence GIAB background bedfiles can be specified here|
 ||`inclusion`: (optional) a regex to match against experimental replicate entry in manifest (see below). only reports containing samples matching this pattern will be run against these confident regions. if not included, this region is used for all reports|
-|`stratification-regions`|intended to be the GIAB stratification regions, as described [here](https://github.com/genome-in-a-bottle/genome-stratifications). the remote directory will be mirrored locally with lftp. these entries are specified as:|
+|`stratification-regions`|intended to be the GIAB stratification regions, as described [here](https://github.com/genome-in-a-bottle/genome-stratifications). the remote directory will be mirrored locally. these entries are specified as:|
 ||`ftp`: the ftp hosting site|
 ||`dir`: the subdirectory of the ftp hosting site, through the genome build directory|
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -10,6 +10,7 @@ from snakemake.utils import validate
 import yaml
 
 S3 = S3RemoteProvider()
+HTTP = HTTPRemoteProvider()
 
 sys.path.insert(0, ".")
 from lib import resource_calculator as rc

--- a/workflow/envs/lftp.yaml
+++ b/workflow/envs/lftp.yaml
@@ -1,4 +1,0 @@
-channels:
-  - conda-forge
-dependencies:
-  - lftp

--- a/workflow/rules/happy.smk
+++ b/workflow/rules/happy.smk
@@ -10,7 +10,8 @@ checkpoint happy_create_stratification_subset:
     to address the fact that hap.py is a giant resource hog.
     """
     input:
-        "results/stratification-sets/{genome_build}/stratification_regions.tsv",
+        "results/stratification-sets/{genome_build}.stratification_regions.tsv",
+        lambda wildcards: tc.get_required_stratifications(wildcards, config, checkpoints),
     output:
         "results/stratification-sets/{genome_build}/subsets_for_happy/{stratification_set}/stratification_subset.tsv",
     params:
@@ -39,6 +40,9 @@ rule happy_run:
         sdf="results/{}/ref.fasta.sdf".format(reference_build),
         stratification="results/stratification-sets/{}/subsets_for_happy/{{stratification_set}}/stratification_subset.tsv".format(
             reference_build
+        ),
+        stratification_files=lambda wildcards: tc.get_required_stratifications(
+            wildcards, config, checkpoints
         ),
         bed="results/confident-regions/{region}.bed",
         rtg_wrapper="workflow/scripts/rtg.bash",


### PR DESCRIPTION
an end user reported issues with lftp being unable to connect behind sufficient stringent firewalls. the tracking in the workflow was lazy in any case. I've updated things to checkpoint on the stratification file linker correctly and track stratification set provenance individually. one minor issue here is that the full set of stratifications is now tracked for all happy comparisons; this is overly conservative in some instances, and will create a fairly heavy spurious rerun burden.