### PR TITLE
feat: support multiple input vcfs per experimental sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- input experimental datasets can be specified as multiple vcfs with the same identifier on multiple rows.
+  the corresponding vcfs will be concatenated and sorted before use. the intended use case of this functionality
+  is on-the-fly combination of single-sample single-chromosome vcfs.
+
 ### Changed
 
 - user configuration is fairly heavily refactored to be more legible/less susceptible to typos

--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ The following columns are expected in the experiment manifest, by default at `co
 
 |Manifest Entry|Description|
 |---|---|
-|`experimental_dataset`|arbitrary, unique alias for this experimental dataset|
+|`experimental_dataset`|arbitrary identifier for this dataset|
 |`replicate`|identifier linking experimental subjects representing the same underlying sample and conditions. this identifier will be used to collapse multiple subjects into single mean/SE estimates in the downstream report, if multiple subjects with the same identifier are included in the same report|
 |`vcf`|path to experimental dataset vcf|
+
+Note that for the experimental manifest, multiple rows with the same `experimental_dataset` value can be included with different corresponding vcfs. If this is the case, the multiple vcfs will be concatenated and sorted into a single vcf before validation. The intended use case of this functionality is on-the-fly concatenation of single chromosome vcfs per sample.
 
 The following columns are expected in the reference manifest, by default at `config/manifest_reference.tsv`:
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -35,9 +35,7 @@ tempDir = "temp"
 manifest_experiment = config["experiment-manifest"]
 manifest_reference = config["reference-manifest"]
 manifest_comparisons = config["comparisons-manifest"]
-manifest_experiment = pd.read_csv(manifest_experiment, sep="\t").set_index(
-    "experimental_dataset", drop=False
-)
+manifest_experiment = pd.read_csv(manifest_experiment, sep="\t")
 manifest_reference = pd.read_csv(manifest_reference, sep="\t").set_index(
     "reference_dataset", drop=False
 )

--- a/workflow/rules/truvari.smk
+++ b/workflow/rules/truvari.smk
@@ -6,7 +6,7 @@ rule tabix_index:
     input:
         "results/{dataset}/{prefix}.vcf.gz",
     output:
-        "results/{dataset,references|experimentals}/{prefix}.vcf.gz.tbi",
+        temp("results/{dataset,references|experimentals}/{prefix}.vcf.gz.tbi"),
     conda:
         "../envs/bcftools.yaml"
     threads: config_resources["bcftools"]["threads"]


### PR DESCRIPTION
a single sample with e.g. chromosomes split into separate vcfs can be specified on multiple rows of the input experimental manifest. the vcfs will be concatenated and merged before evaluation.