### PR TITLE
fix: change reference to invalid input to correct params statement

### DIFF
--- a/workflow/rules/acquire_data.smk
+++ b/workflow/rules/acquire_data.smk
@@ -19,7 +19,7 @@ rule download_reference_data:
         mem_mb=config_resources["default"]["memory"],
     shell:
         "if [[ {params} = s3://* ]] ; then "
-        "aws s3 cp {input} {output} ; "
+        "aws s3 cp {params} {output} ; "
         "elif [[ {params} = ftp://* ]] || [[ {params} = https://* ]] || [[ {params} = http://* ]] ; then "
         "wget -O {output} {params} ; "
         "else cp {params} {output} ; fi"

--- a/workflow/rules/reference_data.smk
+++ b/workflow/rules/reference_data.smk
@@ -61,7 +61,7 @@ rule acquire_confident_regions:
         mem_mb=config_resources["default"]["memory"],
     shell:
         "if [[ {params.source} = s3://* ]] ; then "
-        "aws s3 cp {input} {output.tmp} ; "
+        "aws s3 cp {params.source} {output.tmp} ; "
         "elif [[ {params.source} = ftp://* ]] || [[ {params.source} = https://* ]] || [[ {params.source} = http://* ]] ; then "
         "wget -O {output.tmp} {params.source} ; "
         "else cp {params.source} {output.tmp} ; fi && "


### PR DESCRIPTION
this statement was never updated when remotes were removed